### PR TITLE
Simplify getting project name and version from maven for use in scripts and at runtime.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
     <resources>
       <resource>
         <directory>${basedir}/src/main/resources</directory>
+        <filtering>true</filtering>
       </resource>
     </resources>
     <testResources>

--- a/src/main/java/com/testedminds/template/Routes.java
+++ b/src/main/java/com/testedminds/template/Routes.java
@@ -12,11 +12,12 @@ import static spark.Spark.*;
 public class Routes {
 
   public Routes(ExampleDao dao, int serverPort) {
+    String version = Version.get();
+
     port(serverPort);
 
     get("/", (req, res) ->
-        "It's time to sparkle and shine! See the README to get started. Version: " +
-            Version.from(this.getClass()));
+        "It's time to sparkle and shine! See the README to get started. Version: " + version);
 
     get("/examples/:id", new GetExampleHandler(dao));
     post("/examples", new PostExampleHandler(dao));

--- a/src/main/java/com/testedminds/template/util/Version.java
+++ b/src/main/java/com/testedminds/template/util/Version.java
@@ -1,18 +1,26 @@
 package com.testedminds.template.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
+import java.io.InputStream;
+import java.util.Properties;
 
 public class Version {
 
-  public static String from(Class clazz) {
-    return parseClassLocation(clazz.getProtectionDomain().getCodeSource().getLocation().getPath());
-  }
+  private final static Logger logger = LoggerFactory.getLogger(Version.class);
 
-  static String parseClassLocation(String codePath) {
-    String maybeJar = new File(codePath).getName();
-    if (maybeJar.contains("test-classes")) return "test";
-    int dot = maybeJar.lastIndexOf(".");
-    if (dot < 0) return "development";
-    return maybeJar.substring(0, dot);
+  public static String get() {
+    try {
+      Properties prop = new Properties();
+      prop.load(Version.class.getResourceAsStream("/build.properties"));
+      String name = prop.getProperty("name");
+      String version = prop.getProperty("version");
+      return name + "-" + version;
+    } catch (Exception ex) {
+      logger.error("Could not load build.properties from project resources.");
+      return "";
+    }
   }
 }

--- a/src/main/resources/build.properties
+++ b/src/main/resources/build.properties
@@ -1,0 +1,2 @@
+version=${pom.version}
+name=${project.artifactId}

--- a/src/test/java/com/testedminds/template/RestfulApiFunctionalTest.java
+++ b/src/test/java/com/testedminds/template/RestfulApiFunctionalTest.java
@@ -13,7 +13,7 @@ public class RestfulApiFunctionalTest extends FunctionalTestSuite {
   @Test
   public void getRootIncludesVersionAndReturnsOK() throws Exception {
     String response = http.get(DEFAULT_HOST_URL, 200);
-    assertTrue(response.contains("Version: development"));
+    assertTrue(response.contains("Version: sparkler-"));
   }
 
   @Test

--- a/src/test/java/com/testedminds/template/util/VersionTest.java
+++ b/src/test/java/com/testedminds/template/util/VersionTest.java
@@ -3,20 +3,11 @@ package com.testedminds.template.util;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class VersionTest {
   @Test
   public void shouldGetProjectVersion() {
-    assertEquals("test", Version.from(this.getClass()));
-  }
-
-  @Test
-  public void shouldHandleDevCase() {
-    assertEquals("development", Version.parseClassLocation("/tmp/foo/classes"));
-  }
-
-  @Test
-  public void shouldHandleRunningInJar() {
-    assertEquals("sparkler-1.0.0-standalone", Version.parseClassLocation("/tmp/foo/sparkler-1.0.0-standalone.jar"));
+    assertTrue(Version.get().contains("sparkler"));
   }
 }


### PR DESCRIPTION
Found a much more reliable way to have maven write the project name and version to a file in resources. This can then be read by the makefile and has the bonus of being available at runtime, which removes the need to rely solely on the name of the jar.